### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,53 +1,209 @@
-Revision history for Webservice-InterMine
+Revision history for Perl module Webservice::InterMine
 
-0.94    Monday Sept 13
-        Revised version of the Webservice client for InterMine 0.94 Webservices
+1.0402 2013-10-31 17:27:03 GMT
+        * Bug fix release - failure to set logic correctly in Query::clone.
 
-0.9401  Tue Sep 21 10:24:38 BST 2010
-        * Constraints can be specified with a positional list of parameters
-        * Typos in the Cookbook have been fixed
-0.9402  Tue Sep 21 11:33:19 BST 2010
-        * Removed useless dependency that broke install
-0.9403  Tue Sep 21 14:32:34 BST 2010
-        * Finally removed last reference to IO::String
-0.9407  Fri Oct  8 12:43:11 BST 2010
-        * Readded Perl::Tidy as dependency to fix tests
-        * Changed attribute type in TemplateFactory in response to change in Moose 1.15
-0.9408  Mon Oct 11 13:08:42 BST 2010
-        * Perl::Tidy and YAML::Syck now recommendations.
-        * Changed WriteOutYaml role to dump to string rather than file
-0.9412  Thu Nov 25 18:58:14 GMT 2010
-        * Fixed errors in documentation
-        * Fixed bug with template queries and extra values
-0.9500  Wed Feb  2 17:01:19 GMT 2011
-        * Added support for authenticated requests
-        * Fixed bug in ResultIterator due to loose quotes. Thanks Kim.
-        * Added support for new JSON formats, including inflation
-        * Added bug in Join.pm which was preventing builds.
-0.9501  Thu Feb  3 13:36:04 GMT 2011
-        * Added bug due to mis-matching test counts in acceptance test
-0.9600  Fri Feb 18 16:37:38 GMT 2011
-        * Better verification of version strings, and better coercion of urls
-        * Load queries from local xml
-        * Support for InterMine xml shortcuts (lt for &lt;, etc.)
-        * Tests in support of json rows format
-0.9601  Fri Feb 25 16:26:39 GMT 2011
-        * Bug fixes (including a couple of useless imports)
-        * Queries stringify to their xml representation
-        * More documentation
-0.9602  Mon Feb 28 19:25:19 GMT 2011
-        * Model bug fix required changes to some tests, and 
-          one or two places in the path logic
-0.9603: Tue Mar  1 15:28:18 GMT 2011
-        * Now using the TestModel instance - big effect on test run speed
-0.9604: Thu Mar  3 17:27:14 GMT 2011
-        * Removed last use of testmodel_model.xml, and removed it from dist
-        * Changed logic writer to set_logic for consistency
-        * Added command line utilities
-        * Added moose hygiene test, and made it pass
-        * More POD (especially in important roles)
-        * Added size and start (paging) capabilities to Runnable queries
-0.9605: Sat 12 Mar 2011 21:25:56 EST
+1.0400 2013-04-13
+        * Support for new list date formats from server.
+
+1.0302 2013-08-12 14:43:49 BST
+        * Bug fix release.
+
+1.0300 2013-02-12 19:33:06 GMT
+        * Added delete method to IDResolutionJob.
+
+1.0200 2013-01-15 17:56:13 GMT
+        * Added method to get list of widgets.
+          (Webservice::InterMine::Service::widgets).
+        * Added mechanism for submitting ID resolution jobs
+          and polling for results.
+
+1.0104 2013-01-14 12:27:40 GMT
+        * Added further cook book documentation
+
+1.0101 2012-11-08 19:02:17 GMT
+        * Adding missing file to Manifest.
+
+1.0100 2012-11-06
+        * Fixed error installing under MooseX::Types 0.34
+
+1.0000 2012-10-09 13:39:20 BST
+        * Added support for range constraints.
+        * Updated tests
+
+0.9912 2012-03-21 12:41:34 GMT
+        * Added support for enrichment widgets.
+
+0.9911 2012-02-03 12:07:25 GMT
+        * Added support and tests for lazy attribute fetching.
+
+0.9910 2012-01-18 14:15:52 GMT
+        * Added support for lazy reference fetching,
+          as found in the Python and Ruby clients
+
+0.9909 2012-01-10 19:00:18 GMT
+        * Bux fix release for correct role use to allow extension.
+
+0.9908 2012-01-10 18:38:04 GMT
+        * Use general roles to allow better subclassing.
+
+0.9907 2012-01-10 16:50:01 GMT
+        * Separation of concept of Listable into a general listable
+          and a listable implementation for queries.
+
+        [0.9906 not released]
+        * Added CONTAINS, LIKE, NOT LIKE, DOES NOT CONTAIN,
+          as binary operators.
+
+        [0.9905 not released]
+        * Changed expectations in live tests to take into account the fact
+          that servers now return more thoroughly escaped TSV files.
+
+0.9904 2011-12-09
+        * Added dependency on Set::Crossproduct for testing.
+        * More tests for list constraint construction.
+        * Consistent ability to use subqueries and lists in constraints.
+
+0.9903 2011-12-08
+        * Added coercion for SeviceVersion to cope with the fact
+          that the version service now returns a new line on the end. 
+        * Added more tolerant list creation from queries.
+          Now will accept queries that have non-id fields selected,
+          as long as it is non-ambiguous what is requested.
+
+0.9902 2011-12-07
+        * Added better validation of sort-orders,
+          allowing valid orders that were previously disallowed
+
+0.9901 2011-12-06
+        * Added remove_constraint method. 
+
+0.9900 2011-11-30
+        * Use of new json format where available
+        * Support for redirection and private ports
+        * Use of POST where possible.
+
+0.9819 2011-11-17
+        * Added support for redirected webservice urls.
+
+0.9818 2011-11-16
+        * Some more documentation of result formats,
+          and some tests to go with them.
+
+0.9817 2011-11-16
+        * Updated tests for new fixture set.
+        * Added select method to consumers of the HasQuery role.
+
+0.9816 2011-11-01
+        * Added list-tagging support
+
+0.9815 2011-10-28
+        * Moved simple classes out to own distribution
+          (See: Webservice::InterMine::Simple on CPAN).
+
+0.9814 2011-10-28
+        * Fixed bug in simple service
+
+0.9813 2011-10-27
+        * Added support for the "status" field on lists,
+          so you know if they need manual updating or not.
+
+0.9812 2011-10-25
+        * Added summarise method to runnable queries
+          to get path summary information
+
+0.9811 2011-10-23
+        * Allow ResultRow#to_href to produce either short
+          or long key versions of hrefs
+
+0.9810 2011-10-05
+        * Bug-fix release
+
+0.9809 2011-08-08 17:59:19 BST
+        * Backwards compatibility through to version 3
+          regarding JSON container formats
+
+0.9808 2011-08-05 12:21:23 BST
+        * Export Webservice::InterMine methods by default
+          (with options to exclude them) 
+        * Deprecated username and password authentication on services
+          that support tokens
+
+0.9806 2011-08-02 23:41:12 BST
+        * Made select and add_to_select conform accross clients -
+          select now replaces the view
+
+0.9805 2011-08-02 22:12:57 BST
+        * Switched to JSON::XS for result parsing for performance reasons.
+
+0.9804 2011-08-02 20:49:40 BST
+        * Added ResultRow objects to simplify API
+          (one object for hash and array access). Using Class::InsideOut
+          for memory reasons over MooseX::InsideOut, which leaks.
+        * search and where imply select("*") if the view is empty
+        * Made results default to ResultRows
+
+0.9802 2011-07-26 16:31:59 BST
+        * Aligned handling of parsed sortorders with webserver code
+         (tolerates broken sort-orders)
+
+0.9802 2011-07-24 23:38:52 BST
+        * Added all, first and one to runnable queries.
+        * Add Query::path method for making Path objects
+        * Allowed loop constraints to be built with Path objects.
+
+0.9801 2011-07-24 00:30:47 BST
+        * Revised cookbook, chapters 1-5
+        * Added cookbook tests (runnable examples) 
+        * Added more POD
+        * Added sugar for constraints and views
+          - Query::select for views
+          - Query::where for constraints
+          - Query::search for constraints + results
+          - Service::resultset for queries
+        * Added more aliases, with docs, including
+          - Query::count/get_count
+        * Hid internal methods, such as Query::push_constraints (and others)
+        * Changed logic behaviour on adding constraint
+          (don't discard current logic completely)
+
+0.9800 2011-07-11
+        * Added tokens for authentication
+
+0.9705 2011-06-08 19:34:43 BST
+        * Avoid hitting url limits by posting where possible
+
+0.9704 2011-06-05
+        * Added possible values service methods.
+
+0.9703 2011-06-05
+        * Bug-fix release - subclass parsing was broken
+
+0.9702 2011-06-05
+        * Bug-fix release - Fixed handling of empty result sets - added test
+          for recently fixed bugs.
+
+0.9702 2011-06-04
+        * Bug-fix release - subclass parsing was broken
+
+0.9701 2011-06-04
+        * Improved template parsing speed by only parsing what is requested
+        * Improved show printing format with more appropriate column sizes,
+          and column guides.
+
+0.9700 2011-06-02
+        * Changed result parsing logic - uses a JSON format internally for all 
+          non trivial parsing to ensure safety of field content and diagnostics 
+          of errors.
+        * Enabled lazy iteration of result sets by default.
+          This improves responsiveness for large datasets.
+        * Incorporated iteration into queries as a transparent feature.
+        * Added list services (creation, deletion, renaming, intersection,
+          unions, differences, subtraction, appending)
+        * Added summary methods (show)
+        * Added template and query upload methods
+
+0.9605 2011-03-12
         * Added Webservice::InterMine::Simple (see benchmarks)
             There is a compilation penalty inherent in the use of Moose
             and meta-class introspection. While perfectly acceptable 
@@ -57,119 +213,70 @@ Revision history for Webservice-InterMine
             Webservice::InterMine::Simple will gain a full magnitude increase
             in performance (3.5p/s vs 0.33p/s). However, multiple queries
             within the same process do not see a similar improvement, it being
-            more in the range of 300% (70p/s vs 250p/s). Where speed is important,
-            and more sophisticated features are not required, a Simple service
-            may be appealing
+            more in the range of 300% (70p/s vs 250p/s). Where speed is
+            important, and more sophisticated features are not required,
+            a Simple service may be appealing
          * Added support for headers.
-0.9700: Wed 2 June 2011
-        * Changed result parsing logic - uses a JSON format internally for all 
-          non trivial parsing to ensure safety of field content and diagnostics 
-          of errors.
-        * Enabled lazy iteration of result sets by default. This improves responsiveness
-        for large datasets.
-        * Incorporated iteration into queries as a transparent feature.
-        * Added list services (creation, deletion, renaming, intersection, unions, differences, subtraction, appending)
-        * Added summary methods (show)
-        * Added template and query upload methods
-0.9701: Sat 4 June 2011
-        * Improved template parsing speed by only parsing what is requested
-        * Improved show printing format with more appropriate column sizes, and column guides.
-0.9702: Sat 4 June 2011
-        * Bug-fix release - subclass parsing was broken
-0.9702: Sun 5 June 2011
-        * Bug-fix release - Fixed handling of empty result sets - added test
-        for recently fixed bugs.
-0.9703: Sun 5 June 2011
-        * Bug-fix release - subclass parsing was broken
-0.9704: Sun 5 June 2011
-        * Added possible values service methods.
-0.9705: Wed Jun  8 19:34:43 BST 2011
-        * Avoid hitting url limits by posting where possible
-0.9800: Added tokens for authentication
-0.9801: Sun Jul 24 00:30:47 BST 2011
-        Revised cookbook, chapters 1-5
-        Added cookbook tests (runnable examples) 
-        Added more POD
-        Added sugar for constraints and views
-          * Query::select for views
-          * Query::where for constraints
-          * Query::search for constraints + results
-          * Service::resultset for queries
-        Added more aliases, with docs, including
-          * Query::count/get_count
-        Hid internal methods, such as Query::push_constraints (and others)
-        Changed logic behaviour on adding constraint (don't discard current logic completely)
-0.9802: Sun Jul 24 23:38:52 BST 2011
-        * Added all, first and one to runnable queries.
-        * Add Query::path method for making Path objects
-        * Allowed loop constraints to be built with Path objects.
-0.9802: Tue Jul 26 16:31:59 BST 2011
-        * Aligned handling of parsed sortorders with webserver code (tolerates broken sort-orders)
-0.9804: Tue Aug  2 20:49:40 BST 2011
-        * Added ResultRow objects to simplify API (one object for hash and array access). Using Class::InsideOut
-        for memory reasons over MooseX::InsideOut, which leaks.
-        * search and where imply select("*") if the view is empty
-        * Made results default to ResultRows
-0.9805: Tue Aug  2 22:12:57 BST 2011
-        * Switched to JSON::XS for result parsing for performance reasons.
-0.9806: Tue Aug  2 23:41:12 BST 2011
-        * Made select and add_to_select conform accross clients - select now replaces the view
-0.9808: Fri Aug  5 12:21:23 BST 2011
-        * Export Webservice::InterMine methods by default (with options to exclude them) 
-        * Deprecated username and password authentication on services that support tokens
-0.9809: Mon Aug  8 17:59:19 BST 2011
-        * Backwards compatibility through to version 3 regarding JSON container formats
-0.9810: Bug-fix release
-0.9811: Allow ResultRow#to_href to produce either short or long key versions of hrefs
-0.9812: Added summarise method to runnable queries to get path summary information
-0.9813: Added support for the "status" field on lists, so you know if they need manual updating or not.
-0.9814: Fixed bug in simple service
-0.9815: Moved simple classes out to own distribution (See: Webservice::InterMine::Simple on CPAN).
-0.9816: Added list-tagging support
-0.9817: Updated tests for new fixture set. Added select method to consumers of the HasQuery role.
-0.9818: Some more documentation of result formats, and some tests to go with them.
-0.9819: Added support for redirected webservice urls.
-0.9900: Use of new json format where available
-        Support for redirection and private ports
-        Use of POST where possible.
-0.9901: Added remove_constraint method. 
-0.9902: Added better validation of sort-orders, allowing valid orders that were previously disallowed
-0.9903: Added coercion for SeviceVersion to cope with the fact that the version service now returns a new line on the end. 
-        Added more tolerant list creation from queries. Now will accept queries that have non-id fields selected, as long as it is non-ambiguous what is requested.
-0.9904: Added dependency on Set::Crossproduct for testing.
-        More tests for list constraint construction.
-        Consistent ability to use subqueries and lists in constraints.
-0.9905: Changed expectations in live tests to take into account the fact that servers now return more thoroughly escaped TSV files.
-0.9906: Added CONTAINS, LIKE, NOT LIKE, DOES NOT CONTAIN, as binary operators.
 
-0.9907: Tue Jan 10 16:50:01 GMT 2012
-        Separation of concept of Listable into a general listable and a listable implementation for queries.
-0.9908: Tue Jan 10 18:38:04 GMT 2012
-        Use general roles to allow better subclassing.
-0.9909: Tue Jan 10 19:00:18 GMT 2012
-        Bux fix release for correct role use to allow extension.
-0.9910: Wed Jan 18 14:15:52 GMT 2012
-        Added support for lazy reference fetching, as found in the Python and Ruby clients
-0.9911: Fri Feb  3 12:07:25 GMT 2012
-        Added support and tests for lazy attribute fetching.
-0.9912: Wed Mar 21 12:41:34 GMT 2012
-        Added support for enrichment widgets.
-1.0000: Tue Oct  9 13:39:20 BST 2012
-        Added support for range constraints.
-        Updated tests
-1.0100: Fixed error installing under MooseX::Types 0.34
-1.0101: Thu Nov  8 19:02:17 GMT 2012
-        Adding missing file to Manifest.
-1.0104: Mon Jan 14 12:27:40 GMT 2013
-        Added further cook book documentation
-1.0200: Tue Jan 15 17:56:13 GMT 2013
-        Added method to get list of widgets. (Webservice::InterMine::Service::widgets).
-        Added mechanism for submitting ID resolution jobs and polling for results.
-1.0300: Tue Feb 12 19:33:06 GMT 2013
-        Added delete method to IDResolutionJob.
-1.0302: Mon Aug 12 14:43:49 BST 2013
-        Bug fix release.
-1.0400: Support for new list date formats from server.
-1.0402: Thu Oct 31 17:27:03 GMT 2013
-        Bug fix release - failure to set logic correctly in Query::clone.
+0.9604 2011-03-03 17:27:14 GMT
+        * Removed last use of testmodel_model.xml, and removed it from dist
+        * Changed logic writer to set_logic for consistency
+        * Added command line utilities
+        * Added moose hygiene test, and made it pass
+        * More POD (especially in important roles)
+        * Added size and start (paging) capabilities to Runnable queries
+
+0.9603 2011-03-01 15:28:18 GMT
+        * Now using the TestModel instance - big effect on test run speed
+
+0.9602 2011-02-28 19:25:19 GMT
+        * Model bug fix required changes to some tests, and 
+          one or two places in the path logic
+
+0.9601 2011-02-25 16:26:39 GMT
+        * Bug fixes (including a couple of useless imports)
+        * Queries stringify to their xml representation
+        * More documentation
+
+0.9600 2011-02-18 16:37:38 GMT
+        * Better verification of version strings, and better coercion of urls
+        * Load queries from local xml
+        * Support for InterMine xml shortcuts (lt for &lt;, etc.)
+        * Tests in support of json rows format
+
+0.9501 2011-02-03 13:36:04 GMT
+        * Added bug due to mis-matching test counts in acceptance test
+
+0.9500 2011-02-02 17:01:19 GMT
+        * Added support for authenticated requests
+        * Fixed bug in ResultIterator due to loose quotes. Thanks Kim.
+        * Added support for new JSON formats, including inflation
+        * Added bug in Join.pm which was preventing builds.
+
+0.9412 2010-11-25 18:58:14 GMT
+        * Fixed errors in documentation
+        * Fixed bug with template queries and extra values
+
+0.9408 2010-10-11 13:08:42 BST
+        * Perl::Tidy and YAML::Syck now recommendations.
+        * Changed WriteOutYaml role to dump to string rather than file
+
+0.9407 2010-10-08 12:43:11 BST
+        * Readded Perl::Tidy as dependency to fix tests
+        * Changed attribute type in TemplateFactory in response
+          to change in Moose 1.15
+
+0.9403 2010-09-21 14:32:34 BST
+        * Finally removed last reference to IO::String
+
+0.9402 2010-09-21 11:33:19 BST
+        * Removed useless dependency that broke install
+
+0.9401 2010-09-21 10:24:38 BST
+        * Constraints can be specified with a positional list of parameters
+        * Typos in the Cookbook have been fixed
+
+0.94    2010-09-13
+        * Revised version of the Webservice client for
+          InterMine 0.94 Webservices
 


### PR DESCRIPTION
Hi,

I've reformatted your Changes file to conform to CPAN::Changes::Spec:
- dates are in ISO 8601 date format
- most recent release first
- consistent formatting of bullets for every release
- added dates for the releases that were missing them (dates got from [BackPAN](http://backpan.perl.org/authors/id/I/IN/INTERMINE/))

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil
